### PR TITLE
Update Hall of Flamme recap

### DIFF
--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -1,6 +1,8 @@
 import logging
 import discord
 
+from . import config, database
+
 logger = logging.getLogger(__name__)
 
 async def safe_send_dm(user: discord.User, content: str):
@@ -12,4 +14,43 @@ async def safe_send_dm(user: discord.User, content: str):
         logger.info("DM sent to %s", user)
     except discord.HTTPException as e:
         logger.warning("Failed to send DM to %s: %s", user, e)
+
+
+async def get_top_scores(guild: discord.Guild, limit: int = 5):
+    async with database.db_pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT user_id, points FROM scores ORDER BY points DESC;"
+            )
+            all_rows = await cur.fetchall()
+
+    top_filtered = []
+    for uid, pts in all_rows:
+        member = guild.get_member(int(uid))
+        if member and any(role.id == config.EXCLUDED_ROLE_ID for role in member.roles):
+            continue
+        top_filtered.append((uid, pts))
+        if len(top_filtered) >= limit:
+            break
+    return top_filtered
+
+
+async def build_top5_message(
+    bot: discord.Client,
+    guild: discord.Guild,
+    *,
+    mention_users: bool,
+    header: str,
+) -> str | None:
+    scores = await get_top_scores(guild, 5)
+    if not scores:
+        return None
+
+    icons = ["🥇", "🥈", "🥉", "4️⃣", "5️⃣"]
+    lines = [header]
+    for idx, (uid, pts) in enumerate(scores):
+        user = await bot.fetch_user(int(uid))
+        name = user.mention if mention_users else user.display_name
+        lines.append(f"{icons[idx]} {name} \u2192 {pts} pts")
+    return "\n".join(lines)
 

--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -15,30 +15,30 @@ logger = logging.getLogger(__name__)
 @tasks.loop(minutes=1)
 async def weekly_recap(bot: discord.Client):
     now = datetime.now(timezone.utc)
-    if now.weekday() == 0 and now.hour == 13 and now.minute == 0:
+    today = now.date()
+    if now.hour == 15 and now.minute == 0:
+        last_date = await database.get_last_recap_date(database.db_pool)
+        if last_date is None:
+            return
+        if (today - last_date).days < 2 or await database.has_sent_recap(database.db_pool, today):
+            return
         channel = bot.get_channel(config.HALL_OF_FLAMME_CHANNEL_ID)
         if not channel:
             return
-        guild = channel.guild
-        async with database.db_pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute("SELECT user_id, points FROM scores ORDER BY points DESC;")
-                all_rows = await cur.fetchall()
-        top_filtered = []
-        for uid, pts in all_rows:
-            member = guild.get_member(int(uid))
-            if member and any(role.id == config.EXCLUDED_ROLE_ID for role in member.roles):
-                continue
-            top_filtered.append((uid, pts))
-            if len(top_filtered) >= 3:
-                break
-        if not top_filtered:
+        message = await helpers.build_top5_message(
+            bot,
+            channel.guild,
+            mention_users=True,
+            header="🌟 Hall of Flamme — TOP 5 Kanaé 🌟",
+        )
+        if not message:
             return
-        msg = "📊🌿 @everyone **Classement hebdo des meilleurs fumeurs (Top 3) :**\n"
-        for i, (user_id, points) in enumerate(top_filtered, 1):
-            user = await bot.fetch_user(int(user_id))
-            msg += f"{i}. {user.display_name} ({points} pts)\n"
-        await channel.send(msg)
+        message += (
+            "\n\nRespect à vous les frérots, vous envoyez du très lourd ! Continuez comme ça, le trône du **Kanaé d’Or ** vous attend ! 🛋️🌈"
+            "\n\n🌿 Restez chill, partagez la vibe. Kanaé représente ! 🌿"
+        )
+        await channel.send(message)
+        await database.mark_recap_sent(database.db_pool, today)
         logger.info("Weekly recap sent")
 
 @tasks.loop(minutes=1)


### PR DESCRIPTION
## Summary
- add `get_last_recap_date` and helper methods for top 5 message generation
- redesign `/top-5` command output
- add `/send-first-top-5` command to trigger the first recap
- schedule Hall of Flamme recap every two days after the first send

## Testing
- `python -m py_compile bot/database.py bot/helpers.py bot/commands.py bot/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_6844099305b083259ffa79ddbb97e78a