### PR TITLE
Fix get_top_scores to handle missing members

### DIFF
--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -1,6 +1,8 @@
 import logging
 import discord
 
+from . import config
+
 logger = logging.getLogger(__name__)
 
 async def safe_send_dm(user: discord.User, content: str):
@@ -13,3 +15,21 @@ async def safe_send_dm(user: discord.User, content: str):
     except discord.HTTPException as e:
         logger.warning("Failed to send DM to %s: %s", user, e)
 
+async def get_top_scores(pool, guild: discord.Guild, limit=5):
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT user_id, points FROM scores ORDER BY points DESC;"
+            )
+            rows = await cur.fetchall()
+    results = []
+    for uid, pts in rows:
+        member = guild.get_member(int(uid))
+        if not member:
+            continue
+        if any(role.id == config.EXCLUDED_ROLE_ID for role in member.roles):
+            continue
+        results.append((uid, pts))
+        if len(results) >= limit:
+            break
+    return results

--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -1,7 +1,7 @@
 import logging
 import discord
 
-from . import config
+from . import config, database
 
 logger = logging.getLogger(__name__)
 
@@ -15,21 +15,44 @@ async def safe_send_dm(user: discord.User, content: str):
     except discord.HTTPException as e:
         logger.warning("Failed to send DM to %s: %s", user, e)
 
-async def get_top_scores(pool, guild: discord.Guild, limit=5):
-    async with pool.acquire() as conn:
+
+async def get_top_scores(guild: discord.Guild, limit: int = 5):
+    async with database.db_pool.acquire() as conn:
         async with conn.cursor() as cur:
             await cur.execute(
                 "SELECT user_id, points FROM scores ORDER BY points DESC;"
             )
-            rows = await cur.fetchall()
-    results = []
-    for uid, pts in rows:
+            all_rows = await cur.fetchall()
+
+    top_filtered = []
+    for uid, pts in all_rows:
         member = guild.get_member(int(uid))
-        if not member:
+        if member is None:
             continue
         if any(role.id == config.EXCLUDED_ROLE_ID for role in member.roles):
             continue
-        results.append((uid, pts))
-        if len(results) >= limit:
+        top_filtered.append((uid, pts))
+        if len(top_filtered) >= limit:
             break
-    return results
+    return top_filtered
+
+
+async def build_top5_message(
+    bot: discord.Client,
+    guild: discord.Guild,
+    *,
+    mention_users: bool,
+    header: str,
+) -> str | None:
+    scores = await get_top_scores(guild, 5)
+    if not scores:
+        return None
+
+    icons = ["🥇", "🥈", "🥉", "4️⃣", "5️⃣"]
+    lines = [header]
+    for idx, (uid, pts) in enumerate(scores):
+        user = await bot.fetch_user(int(uid))
+        name = user.mention if mention_users else user.display_name
+        lines.append(f"{icons[idx]} {name} \u2192 {pts} pts")
+    return "\n".join(lines)
+


### PR DESCRIPTION
## Summary
- import `config` into `helpers`
- implement `get_top_scores` helper
- skip users missing from the guild when building scores

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68440e165860832585d8faf2dc479386